### PR TITLE
Upgrade to latest TikTok lib version for android and support android 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,12 @@ Then you can get authorization token
 ```
 var code = await TiktokLoginFlutter.authorize("user.info.basic,video.list");
 ```
+
+Due to changes in Android 11 regarding package visibility, when impementing Tiktok SDK for devices targeting Android 11 and higher, add the following to the Android Manifest file:
+
+```
+<queries>
+    <package android:name="com.zhiliaoapp.musically" />
+    <package android:name="com.ss.android.ugc.trill" />
+</queries>
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,5 +50,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.bytedance.ies.ugc.aweme:opensdk-oversea-external:0.2.0.2'
+    implementation 'com.bytedance.ies.ugc.aweme:opensdk-oversea-external:0.2.1.0'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.raiinmaker.tiktok_login_flutter">
+    <queries>
+        <package android:name="com.zhiliaoapp.musically" />
+        <package android:name="com.ss.android.ugc.trill" />
+    </queries>
     <application>
         <activity
             android:name=".tiktokapi.TikTokEntryActivity"
             android:exported="true">
-
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
Resolve exception when trying to open Tiktok App: Android.content.pm.PackageManager$NameNotFoundException: ComponentInfo{com.zhiliaoapp.musically/com.zhiliaoapp.musically.openauthorize.AwemeAuthorizedActivity 

Due to changes in Android 11 regarding package visibility, when impementing Tiktok SDK for devices targeting Android 11 and higher.
 [master](https://github.com/shadyshrif/tiktok_login_flutter)